### PR TITLE
Added custom upload name & output format, fix #10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,21 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
+    "@types/caseless": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
+      "dev": true
+    },
+    "@types/form-data": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/inquirer": {
       "version": "0.0.42",
       "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.42.tgz",
@@ -39,6 +54,27 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.45.tgz",
       "integrity": "sha512-tGVTbA+i3qfXsLbq9rEq/hezaHY55QxQLeXQL2ejNgFAxxrgu8eMmYIOsRcl7hN1uTLVsKOOYacV/rcJM3sfgQ==",
       "dev": true
+    },
+    "@types/request": {
+      "version": "2.48.1",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.1.tgz",
+      "integrity": "sha512-ZgEZ1TiD+KGA9LiAAPPJL68Id2UWfeSO62ijSXZjFJArVV+2pKcsVHmrcu+1oiE3q6eDGiFiSolRc4JHoerBBg==",
+      "dev": true,
+      "requires": {
+        "@types/caseless": "*",
+        "@types/form-data": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*"
+      }
+    },
+    "@types/request-promise-native": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@types/request-promise-native/-/request-promise-native-1.0.15.tgz",
+      "integrity": "sha512-uYPjTChD9TpjlvbBjNpZfNc64TBejBS52u7pbxhQLnlxw+5Em7wLb6DU2wdJVhJ2Mou7v50N0qgL4Gia5mmRYg==",
+      "dev": true,
+      "requires": {
+        "@types/request": "*"
+      }
     },
     "@types/rx": {
       "version": "4.1.1",
@@ -174,6 +210,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/tough-cookie": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-2.3.5.tgz",
+      "integrity": "sha512-SCcK7mvGi3+ZNz833RRjFIxrn4gI1PPR3NtuIS+6vMkvmsGjosqTJwRt5bAEFLRz+wtJMWv8+uOnZf2hi2QXTg==",
+      "dev": true
     },
     "address": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,16 @@
           "markdownDescription": "%config.logPath.description%",
           "default": ""
         },
+        "picgo.customUploadName": {
+          "type": "string",
+          "markdownDescription": "%config.customUploadName.description%",
+          "default": "${fileName}"
+        },
+        "picgo.customOutputFormat": {
+          "type": "string",
+          "markdownDescription": "%config.customOutputFormat.description%",
+          "default": "![${uploadedName}](${url})"
+        },
         "picgo.picBed.current": {
           "type": "string",
           "enum": [
@@ -265,6 +275,7 @@
     "@types/inquirer": "0.0.42",
     "@types/mocha": "^2.2.42",
     "@types/node": "^8.10.25",
+    "@types/request-promise-native": "^1.0.15",
     "cz-conventional-changelog": "2.1.0",
     "tslint": "^5.8.0",
     "typescript": "^2.6.1",

--- a/package.nls.json
+++ b/package.nls.json
@@ -7,6 +7,8 @@
   "config.title": "PicGo",
   "config.configPath.description": "The path to your PicGo-Core configuration. PicGo will use `#picgo.picBed#` if this is not specified.",
   "config.logPath.description": "The path to your log file. PicGo will use `your_home_dir/vs-picgo-log.json` if this is not specified.",
+  "config.customUploadName.description": "Customize the name of the image to be uploaded, image will be renamed before uploading.\n- `${fileName}`: the name of the original image, without extension name.\n- `${extName}`: the extension name of the original image.\n- `${mdFileName}`: the name of the current editing markdown file.\n- `${date}`: YY-MM-DD formatted date.\n- `${dateTime}`: YY-MM-DD-hh-mm-ss formatted date.\n\nExamples:\n- `${fileName}-${date}` -> `picName-2016-07-25.jpg`\n- `${mdFileName}`-`${dateTime}` -> `markdownName-2017-04-12-222810.jpg`",
+  "config.customOutputFormat.description": "Customize the output format of the uploaded image.\n- `${url}`: the url of the uploaded image.\n- `${uploadedName}`: the name of the uploaded image, see `#picgo.customUploadName#`.\n\nExamples:\n- `![${uploadedName}](${url})` -> `![picName-2016-07-25](https://example.com/xxx.jpg)`\n- `<img src=\"${url}\" alt=\"${uploadedName}\">` -> `<img src=\"https://example.com/xxx.jpg\" alt=\"picName-2016-07-25\">`",
   "config.picBed.description": "PicGo-Core configuration, please see https://picgo.github.io/PicGo-Core-Doc/zh/guide/config.html#picbed.",
   "config.picBed.smms.description": "SM.MS picBed configuration.",
   "config.picBed.weibo.description": "Weibo picBed configuration.",


### PR DESCRIPTION
### Custom upload name & output format

- Added: custom upload name & output format
- Added: show error message on picgo error and cancel the upload progress dialog.

Configuration screenshot:

![20190406172554.png](https://i.loli.net/2019/04/06/5ca870a5bc6e4.png)

#### custom upload name & output format

##### Single image upload

![](https://i.loli.net/2019/04/06/5ca87104610d5.gif)

##### Multiple images upload

![](https://i.loli.net/2019/04/06/5ca871000353d.gif)

#### better error message

![vs-picgo-error.gif](https://i.loli.net/2019/04/06/5ca86fa509fdb.gif)

Inspired by:

- [vscode-paste-image-to-qiniu](https://github.com/favers/vscode-qiniu-upload-image)
- [picgo-plugin-autocopy](https://github.com/PicGo/picgo-plugin-autocopy)

PS: I found another bug, when I uploaded several large images (for example, the two gif's above) using `smms` (on version 1.0.6 and until this PR), I always got the `socket hang up` error, I'm not sure if it is my network issue, but upload using browser is okay. This should be okay if user don't upload very large files. I think if may be a bug of `PicGo-Core`.