### PR TITLE
Setup continuous integration appveyor & azure 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,5 @@
+variables:
+  system.debug: true
 jobs:
   - job: Windows
     pool:
@@ -20,6 +22,17 @@ jobs:
           customCommand: 'run compile'
       - script: 'node node_modules/vscode/bin/test'
         displayName: 'Run tests'
+      - script: 'npm install -g vsce && vsce package'
+        displayName: 'Build artifact'
+      - task: CopyFiles@2
+        inputs:
+          contents: '*.vsix'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: vs-picgo-dev-build-Windows
+
   - job: macOS
     pool:
       name: Hosted macOS
@@ -41,6 +54,16 @@ jobs:
           customCommand: 'run compile'
       - script: 'node node_modules/vscode/bin/test'
         displayName: 'Run tests'
+      - script: 'npm install -g vsce && vsce package'
+        displayName: 'Build artifact'
+      - task: CopyFiles@2
+        inputs:
+          contents: '*.vsix'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: vs-picgo-dev-build-macOS
   - job: Linux
     pool:
       name: Hosted Ubuntu 1604
@@ -69,6 +92,16 @@ jobs:
         displayName: 'Run tests'
         env:
           DISPLAY: :10
+      - script: 'npm install -g vsce && vsce package'
+        displayName: 'Build artifact'
+      - task: CopyFiles@2
+        inputs:
+          contents: '*.vsix'
+          TargetFolder: '$(Build.ArtifactStagingDirectory)'
+      - task: PublishBuildArtifacts@1
+        inputs:
+          pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+          artifactName: vs-picgo-dev-build-Linux
 trigger:
 - master
 - dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,76 @@
+jobs:
+  - job: Windows
+    pool:
+      name: Hosted VS2017
+      demands: npm
+    steps:
+      - task: NodeTool@0
+        displayName: 'Use Node 8.x'
+        inputs:
+          versionSpec: 8.x
+      - task: Npm@1
+        displayName: 'Install dependencies'
+        inputs:
+          verbose: false
+      - task: Npm@1
+        displayName: 'Compile sources'
+        inputs:
+          command: custom
+          verbose: false
+          customCommand: 'run compile'
+      - script: 'node node_modules/vscode/bin/test'
+        displayName: 'Run tests'
+  - job: macOS
+    pool:
+      name: Hosted macOS
+      demands: npm
+    steps:
+      - task: NodeTool@0
+        displayName: 'Use Node 8.x'
+        inputs:
+          versionSpec: 8.x
+      - task: Npm@1
+        displayName: 'Install dependencies'
+        inputs:
+          verbose: false
+      - task: Npm@1
+        displayName: 'Compile sources'
+        inputs:
+          command: custom
+          verbose: false
+          customCommand: 'run compile'
+      - script: 'node node_modules/vscode/bin/test'
+        displayName: 'Run tests'
+  - job: Linux
+    pool:
+      name: Hosted Ubuntu 1604
+      demands: npm
+    steps:
+      - task: NodeTool@0
+        displayName: 'Use Node 8.x'
+        inputs:
+          versionSpec: 8.x
+      - task: Npm@1
+        displayName: 'Install dependencies'
+        inputs:
+          verbose: false
+      - task: Npm@1
+        displayName: 'Compile sources'
+        inputs:
+          command: custom
+          verbose: false
+          customCommand: 'run compile'
+      - script: |
+          set -e
+          /usr/bin/Xvfb :10 -ac >> /tmp/Xvfb.out 2>&1 &
+          disown -ar
+        displayName: 'Start xvfb'
+      - script: 'node node_modules/vscode/bin/test'
+        displayName: 'Run tests'
+        env:
+          DISPLAY: :10
+trigger:
+- master
+- dev
+- dev-dora
+- dev-spades


### PR DESCRIPTION
To make future test and release more productive, I have already added and tested CI on `appveyor` and `azure pipelines`, both are okay on my own fork and all branches. See artifact built using the source of my fork on [appveyor](https://ci.appveyor.com/project/PicGo/vs-picgo-jd0s2/builds/23750686/artifacts) and [azure pipelines](https://dev.azure.com/upupming/vs-picgo/_build/results?buildId=14&view=results). And GitHub show as below:

![image](https://user-images.githubusercontent.com/24741764/55905154-ffeead00-5c03-11e9-8f25-3d1ba8c4a726.png)

I think azure is more promising as it will test on different platforms (linux, windows, and macOS). But appveyor is much faster.

<hr>

However, it seems that I don't have sufficient privilege to set up these environments to PicGo/vs-picgo, could you please help?

Steps you may need to take:

1. Merge this PR to master.
2. Goto https://ci.appveyor.com/project/picgo/vs-picgo and https://azure.microsoft.com/en-us/services/devops/pipelines/ to properly authenticate this repo.
3. Start a build and see if the artifact is built successfully, and also test if commits on dev branch will be automatically built.

Thanks for your patience in advance!