### PR TITLE
Make Publish Action Independent

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -24,11 +24,6 @@ jobs:
           yarn compile
           xvfb-run --auto-servernum yarn test
 
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
@@ -42,10 +37,3 @@ jobs:
           tag_name: ${{ github.ref }}
           body: |
             Please refer to [CHANGELOG.md](https://github.com/PicGo/vs-picgo/blob/${{ steps.get_version.outputs.VERSION }}/CHANGELOG.md) for details.
-
-      - name: Publish to VSCode Marketplace
-        uses: lannonbr/vsce-action@master
-        with:
-          args: 'publish -p $VSCE_TOKEN'
-        env:
-          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}

--- a/.github/workflows/vsce-publish.yml
+++ b/.github/workflows/vsce-publish.yml
@@ -1,0 +1,32 @@
+on:
+  pull_request:
+    branches:
+      - main
+
+name: VSCode Marketplace Publish
+
+jobs:
+  build:
+    name: VSCode Marketplace Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      # https://github.com/juliangruber/browser-run/issues/147#issuecomment-580958935
+      - run: sudo apt-get install xvfb
+
+      - name: yarn install, compile, and test coverage
+        run: |
+          yarn install
+          yarn compile
+          xvfb-run --auto-servernum yarn test
+
+      - name: Publish to VSCode Marketplace
+        uses: lannonbr/vsce-action@master
+        with:
+          args: 'publish -p $VSCE_TOKEN'
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}


### PR DESCRIPTION
Add `vsce-publish` action to publish `vs-picgo` on VSCode Marketplace