### PR TITLE
:sparkles: Feature(settings): read from client when running with VsCode Remote

### DIFF
--- a/package.json
+++ b/package.json
@@ -312,6 +312,7 @@
       }
     }
   },
+  "extensionKind": ["ui"],
   "scripts": {
     "vscode:prepublish": "yarn && yarn build:prod",
     "build": "node esbuild.mjs",


### PR DESCRIPTION
当使用vscode remote模式时，目前插件允许在server端运行，此时剪贴板读取的是server端，使用很不方便。文件读取的也是server端，这个对我个人来说比较鸡肋（也不太方便）。
个人进行了一些探索，受限于API的能力，暂时无法做到插件运行在远端的时候读取client端文件和剪贴板，因此建议将插件运行的host锁定为UI（也就是仅在client端运行），看看是否OK？
ExtentionKind参数的官方文档：https://code.visualstudio.com/api/advanced-topics/extension-host